### PR TITLE
Use YearNav for gallery navigation

### DIFF
--- a/src/components/filters/yearNav.js
+++ b/src/components/filters/yearNav.js
@@ -2,8 +2,11 @@ import React from "react";
 
 import "./yearNav.scss";
 
-export default ({ years, setYear, currentYear }) => (
+export default ({ years, setYear, currentYear, showPrevNext = false }) => (
     <ul className="yearNav">
+        {showPrevNext && 
+            <li><button class="prevNext" onClick={() => setYear( (currentYear === 1) ? (years.length) : currentYear - 1 )}>previous</button></li>
+        }
         {years.map((y) => (
             <li>
                 <button
@@ -14,5 +17,10 @@ export default ({ years, setYear, currentYear }) => (
                 </button>
             </li>
         ))}
+        {showPrevNext &&
+            <li>
+                <button class="prevNext" onClick={() => setYear((currentYear === years.length) ? 1 : currentYear + 1)}>next</button>
+            </li>
+        }
     </ul>
 );

--- a/src/components/filters/yearNav.scss
+++ b/src/components/filters/yearNav.scss
@@ -49,5 +49,9 @@
                 }
             }
         }
+
+        .prevNext {
+            @extend %year;
+        }
     }
 }

--- a/src/components/shared/gallery.js
+++ b/src/components/shared/gallery.js
@@ -1,9 +1,19 @@
 import React, { useState } from "react";
 
+import GalleryNav from "../filters/yearNav";
+
 import "./gallery.scss"
 
 export default ({ assets, name }) => {
   const [current, setCurrent] = useState(0);
+
+  // Compensate for zero indexing in the rest of the component.
+  const setCurrentZeroIndexed = (x) => {
+    setCurrent( x -1 );
+  }
+
+  // Fast way to generate an integer array that can be sent to the existing YearNav component.
+  const assetIndex = Array.from(Array(assets.length + 1).keys()).slice(1);
 
   return (
     <div className="gallery">
@@ -29,6 +39,7 @@ export default ({ assets, name }) => {
           </button>
         ))}
       </div>
+      <GalleryNav years={assetIndex} setYear={setCurrentZeroIndexed} currentYear={current + 1} showPrevNext={true} />
     </div>
   )
 };


### PR DESCRIPTION
Not beautiful, but uses existing YearNav component to render the gallery navigation.  Shoehorns it a bit, because the internals of the gallery work on the zero-indexed array position, while the YearNav component uses the content of the array value.

Not sure ultimately if the YearNav component should be further generalized to serve both use cases, or if these should be 2 separate components.