### PR TITLE
Use flex for main container layout

### DIFF
--- a/src/components/layout.scss
+++ b/src/components/layout.scss
@@ -59,7 +59,10 @@ body {
 }
 
 #container {
-    min-height: 100%; 
+    display: flex;
+    flex-direction: column;
+
+    min-height: 100vh;
     margin-bottom: -94px;
 
     margin: auto;
@@ -106,6 +109,8 @@ body {
         width: 940px;
         padding-left: 20px;
         padding-right: 20px;
+
+        flex-grow: 1;
     }
 
 }


### PR DESCRIPTION
In order to keep the footer at the bottom of the page for short pages.  Otherwise the footer floats up to the bottom of the content.