### PR TITLE
Add category for postdoctoral fellow

### DIFF
--- a/src/components/peopleList.js
+++ b/src/components/peopleList.js
@@ -8,6 +8,7 @@ import './peopleList.scss';
 const categories = [
   'Professor',
   'Postdoctoral Associate',
+  'Postdoctoral Fellow',
   'Ph.D. Candidate',
   'M.S. Candidate',
   'Visiting Scientist',


### PR DESCRIPTION
Add a category for Postdoctoral Fellows.

This should really come from a database endpoint, but it doesn't change very often, so it has been easier to hardcode it here.