### PR TITLE
Update buildspec with specific nodejs version

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,5 +1,8 @@
 version: 0.1
 phases:
+  install:
+    runtime-versions:
+      nodejs: 18
   pre_build:
     commands:
       - npm i -g npm && npm ci --unsafe-perm


### PR DESCRIPTION
This tells codebuild to use nodejs 18, which is the minimum requirement for the latest version of npm.
