### PR TITLE
Documentation and text changes

### DIFF
--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -21,27 +21,28 @@ FileMaker is an external system (hosted by a partner) and is not a repo.
 This diagram shows the three repos as black boxes with labeled flows between them. It intentionally omits internal AWS component detail — see the Miro board for the full internal architecture of `superfluid-images`.
 
 ```mermaid
+%%{init: {"flowchart": {"rankSpacing": 100, "nodeSpacing": 50}} }%%
 flowchart LR
-    FM(["FileMaker\nData Source\n(external)"])
-    Browser(["End User\nBrowser"])
+    FM(["FileMaker Data Source (external)"])
+    Browser(["End User Browser"])
 
     subgraph GATSBY["jdub233/tmg-website-gatsby"]
-        BUILD["Gatsby Build\nReact + SCSS to static files"]
+        BUILD["Gatsby Build — React + SCSS to static files"]
     end
 
     subgraph SUF["jdub233/superfluid-uploader-frontend"]
-        UPUI["Uploader UI React/Vite\nembedded in FileMaker web viewer"]
+        UPUI["Uploader UI — React/Vite — embedded in FileMaker"]
     end
 
     subgraph SFIMG["jdub233/superfluid-images"]
-        MEDIA["AWS SAM\nCloudFront + Lambda@Edge\nS3 + DynamoDB + Upload API"]
+        MEDIA["AWS SAM — CloudFront + Lambda@Edge + S3 + DynamoDB + Upload API"]
     end
 
-    FM -->|"FileMaker REST API\nJSON at build time"| BUILD
-    FM -->|"Embedded web viewer\nasset GUID + API key in URL"| UPUI
-    BUILD -->|"Compiled static files\ndeployed to S3 + CloudFront"| Browser
-    UPUI -->|"1. GET pre-signed URL\n2. PUT file to S3"| SFIMG
-    SFIMG -->|"Media file requests\nvia CloudFront CDN"| Browser
+    FM -->|"FileMaker REST API — JSON at build time"| BUILD
+    FM -->|"Embedded web viewer — asset GUID + API key"| UPUI
+    BUILD -->|"Compiled static files — deployed to S3 + CloudFront"| Browser
+    UPUI -->|"1. GET pre-signed URL  2. PUT file to S3"| SFIMG
+    SFIMG -->|"Media files via CloudFront CDN"| Browser
 ```
 
 **Reading the diagram:**

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -21,7 +21,7 @@ FileMaker is an external system (hosted by a partner) and is not a repo.
 This diagram shows the three repos as black boxes with labeled flows between them. It intentionally omits internal AWS component detail — see the Miro board for the full internal architecture of `superfluid-images`.
 
 ```mermaid
-%%{init: {"flowchart": {"rankSpacing": 100, "nodeSpacing": 50}} }%%
+%%{init: {"flowchart": {"rankSpacing": 150, "nodeSpacing": 100}} }%%
 flowchart LR
     FM(["FileMaker Data Source (external)"])
     Browser(["End User Browser"])

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -1,0 +1,62 @@
+# TMG Website — System Overview
+
+> **For AI coding agents:** This document gives you a map of the full system before you work on any single repo. The diagram below shows repo boundaries and data flows at a high level. Treat each subgraph as a boundary: changes inside one box generally do not require changes in another, but the labeled arrows are the interfaces that must stay consistent.
+
+---
+
+## Repos in this system
+
+| Repo | Purpose |
+|---|---|
+| `jdub233/tmg-website-gatsby` | Gatsby 5 / React 18 frontend. Fetches JSON from FileMaker at build time, compiles to static files, deployed to S3. |
+| `jdub233/superfluid-images` | AWS SAM app: CloudFront CDN, Lambda@Edge (URI rewrite + on-demand resize), S3 storage, DynamoDB GUID-to-filename map, Upload API. |
+| `jdub233/superfluid-uploader-frontend` | React/Vite uploader embedded in FileMaker as a web viewer. Gets pre-signed URLs from superfluid-images, uploads directly to S3. |
+
+FileMaker is an external system (hosted by a partner) and is not a repo.
+
+---
+
+## Level 1 System Overview
+
+This diagram shows the three repos as black boxes with labeled flows between them. It intentionally omits internal AWS component detail — see the Miro board for the full internal architecture of `superfluid-images`.
+
+```mermaid
+flowchart LR
+    FM(["FileMaker\nData Source\n(external)"])
+    Browser(["End User\nBrowser"])
+
+    subgraph GATSBY["jdub233/tmg-website-gatsby"]
+        BUILD["Gatsby Build\nReact + SCSS to static files"]
+    end
+
+    subgraph SUF["jdub233/superfluid-uploader-frontend"]
+        UPUI["Uploader UI React/Vite\nembedded in FileMaker web viewer"]
+    end
+
+    subgraph SFIMG["jdub233/superfluid-images"]
+        MEDIA["AWS SAM\nCloudFront + Lambda@Edge\nS3 + DynamoDB + Upload API"]
+    end
+
+    FM -->|"FileMaker REST API\nJSON at build time"| BUILD
+    FM -->|"Embedded web viewer\nasset GUID + API key in URL"| UPUI
+    BUILD -->|"Compiled static files\ndeployed to S3 + CloudFront"| Browser
+    UPUI -->|"1. GET pre-signed URL\n2. PUT file to S3"| SFIMG
+    SFIMG -->|"Media file requests\nvia CloudFront CDN"| Browser
+```
+
+**Reading the diagram:**
+
+- The left-to-right layout reflects two parallel paths: *content* (Gatsby build) and *media* (Superfluid upload and serve).
+- FileMaker drives both paths: it is the data source for the Gatsby build and the authoring environment for media uploads.
+- The browser receives static HTML/JS/CSS from one origin and media files from a separate CDN origin (`trackr-media.tangiblemedia.org`).
+- `superfluid-uploader-frontend` only participates in the write (upload) path — it is not involved in serving media to end users.
+
+---
+
+## Further detail
+
+- **Miro board** (full internal architecture, upload/serve sequence diagrams):
+  https://miro.com/app/board/uXjVGxJMKN4=/
+- **Notion Project Hub** (stack overview, open work streams, design principles):
+  https://www.notion.so/324ae0c3e70a81c7b8f5ea6b5f8b8499
+- **Per-repo internal diagrams:** See `docs/` in `superfluid-images` and `superfluid-uploader-frontend` (planned).

--- a/docs/system-overview.md
+++ b/docs/system-overview.md
@@ -1,9 +1,5 @@
 # TMG Website — System Overview
 
-> **For AI coding agents:** This document gives you a map of the full system before you work on any single repo. The diagram below shows repo boundaries and data flows at a high level. Treat each subgraph as a boundary: changes inside one box generally do not require changes in another, but the labeled arrows are the interfaces that must stay consistent.
-
----
-
 ## Repos in this system
 
 | Repo | Purpose |
@@ -16,7 +12,7 @@ FileMaker is an external system (hosted by a partner) and is not a repo.
 
 ---
 
-## Level 1 System Overview
+## System Overview
 
 This diagram shows the three repos as black boxes with labeled flows between them. It intentionally omits internal AWS component detail — see the Miro board for the full internal architecture of `superfluid-images`.
 
@@ -56,8 +52,4 @@ flowchart LR
 
 ## Further detail
 
-- **Miro board** (full internal architecture, upload/serve sequence diagrams):
-  https://miro.com/app/board/uXjVGxJMKN4=/
-- **Notion Project Hub** (stack overview, open work streams, design principles):
-  https://www.notion.so/324ae0c3e70a81c7b8f5ea6b5f8b8499
-- **Per-repo internal diagrams:** See `docs/` in `superfluid-images` and `superfluid-uploader-frontend` (planned).
+- **Per-repo internal diagrams:** See `docs/architecture.md` in `superfluid-images` and `superfluid-uploader-frontend`.

--- a/src/pages/vision.js
+++ b/src/pages/vision.js
@@ -38,7 +38,7 @@ function Vision() {
       <div className="text-block">
         <h3 className="box">Seamless Telepresence</h3>
         <p>
-          Telepresence has traditionally pursued the idea of “being there and together“ by overcoming distance through the use of real-time video communication to digitally connect geographically distributed remote participants.
+          Telepresence has traditionally pursued the idea of “being there and together” by overcoming distance through the use of real-time video communication to digitally connect geographically distributed remote participants.
           In the early 1990s, Professor Ishii explored the vision of “Seamless Telepresence” through systems such as <i>ClearBoard</i> while at <i>NTT Human Interface Laboratories</i>. This work sought to dissolve the boundary between remote collaborators by creating the illusion of a seamless shared workspace, where digital and physical media could be fused. By carefully aligning gaze, gesture, and drawing surfaces, <i>ClearBoard</i> enabled participants to read each other’s gaze and facial expressions while simultaneously interacting over a shared workspace.
         </p>
       </div>

--- a/src/pages/vision.js
+++ b/src/pages/vision.js
@@ -36,6 +36,26 @@ function Vision() {
         </div>
       </div>
       <div className="text-block">
+        <h3 className="box">Seamless Telepresence</h3>
+        <p>
+          Telepresence has traditionally pursued the idea of “being there and together“ by overcoming distance through the use of real-time video communication to digitally connect geographically distributed remote participants.
+          In the early 1990s, Professor Ishii explored the vision of “Seamless Telepresence” through systems such as <i>ClearBoard</i> while at <i>NTT Human Interface Laboratories</i>. This work sought to dissolve the boundary between remote collaborators by creating the illusion of a seamless shared workspace, where digital and physical media could be fused. By carefully aligning gaze, gesture, and drawing surfaces, <i>ClearBoard</i> enabled participants to read each other’s gaze and facial expressions while simultaneously interacting over a shared workspace.
+        </p>
+      </div>
+      <div className="text-block">
+        <h3 className="box">TeleAbsence</h3>
+        <p>
+          TeleAbsence proposes a new vision of “Past and Afterlife Telepresence.” Rather than overcoming physical distance, it addresses the profound emotional and temporal distances shaped by fading memories and the loss of loved ones. TeleAbsence embraces absence not as a limitation, but as a fundamental condition and as a new design space.
+          Instead of explicit or literal representations, TeleAbsence explores poetic encounters with the digital and physical traces left behind by others. It fosters illusory communication—evoking the feeling of being with those who are no longer present—without relying on synthetic or generative representations of an absent person.
+          This vision is deeply inspired by the Portuguese concept of saudade—a longing for people, places, and moments made more poignant by their absence. TeleAbsence is guided by five design principles: presence of absence, illusory communication, materiality of memory, traces of reflection, and remote time, which together create opportunities to revisit and re-experience cherished moments.
+          By expanding telepresence to encompass the full spectrum of human existence—from before birth to the afterlife—TeleAbsence offers a framework for engaging with memory, legacy, and loss. Through thoughtful human–computer interaction design, it envisions a future in which personal memories are meaningfully preserved and reconstituted, allowing individuals to reconnect with their past selves and sustain bonds with those who are no longer with us.
+          <b>
+            TeleAbsence expands our capacity to care, to remember, and to see ourselves as part of a longer human arc (continuum). It is a living medium, stretching across generations and weaving fragments of identity into continuity.
+            In this way, memory becomes more than remembrance. It becomes a human bond across time.
+          </b>
+        </p>
+      </div>
+      <div className="text-block">
         <h3 className="box">Vision-driven Design Research</h3>
         <p>
           Looking back on the history of Human-Computer Interaction (HCI), we notice that quantum leaps have rarely resulted from studies on users’ needs; they have instead stemmed from the passion and dreams of visionaries like Dr.  <a href="https://en.wikipedia.org/wiki/Douglas_Engelbart">Douglas Engelbart</a>. By looking beyond current limitations, we believe that vision-driven design is critical to foster these quantum leaps, while also complementing needs-driven and technology-driven design. From Tangible Bits, an early example of our vision-driven research, we shifted to Radical Atoms, which seeks out new guiding principles and concepts to view the world of bits and atoms in a new light, with the goal of trailblazing a new realm in interaction design.


### PR DESCRIPTION
Adds new narrative content to the Vision page and introduces a system-level documentation page describing how this Gatsby site relates to the other repos in the ecosystem.

**Changes:**
- Added new “Seamless Telepresence” and “TeleAbsence” content sections to `src/pages/vision.js`.
- Added `docs/system-overview.md` with a repo list and a Mermaid diagram of cross-repo data/media flows.